### PR TITLE
docs(cn): editors/webstorm translation

### DIFF
--- a/editors/webstorm.md
+++ b/editors/webstorm.md
@@ -1,7 +1,7 @@
 <Logo name="webstorm" class="logo-float-xl"/>
 
-# WebStorm Intellisense
+# WebStorm 智能感知
 
-The support for WebStorm is on our roadmap, but the we haven't get enough bandwidth to working on it yet. 
+对于 WebStorm 的支持在我们的路线图中，但是我们目前没有足够精力来做这件事。
 
-Join the waitlist by [upvoting this comment](https://github.com/windicss/windicss/discussions/136#discussioncomment-557097). Thank you.
+通过 [点赞这条评论](https://github.com/windicss/windicss/discussions/136#discussioncomment-557097) 加入候补名单。谢啦~

--- a/editors/webstorm.md
+++ b/editors/webstorm.md
@@ -2,6 +2,6 @@
 
 # WebStorm 智能感知
 
-对于 WebStorm 的支持在我们的路线图中，但是我们目前没有足够精力来做这件事。
+WebStorm 的支持已在我们的计划中，但我们目前没有足够的精力来实现它。
 
 通过 [点赞这条评论](https://github.com/windicss/windicss/discussions/136#discussioncomment-557097) 加入候补名单。谢啦~

--- a/editors/webstorm.md
+++ b/editors/webstorm.md
@@ -1,6 +1,6 @@
 <Logo name="webstorm" class="logo-float-xl"/>
 
-# WebStorm 智能感知 {#webstorm-intellisense}
+# WebStorm Intellisense {#webstorm-intellisense}
 
 WebStorm 的支持已在我们的计划中，但我们目前没有足够的精力来实现它。
 

--- a/editors/webstorm.md
+++ b/editors/webstorm.md
@@ -1,6 +1,6 @@
 <Logo name="webstorm" class="logo-float-xl"/>
 
-# WebStorm 智能感知
+# WebStorm 智能感知 {#webstorm-intellisense}
 
 WebStorm 的支持已在我们的计划中，但我们目前没有足够的精力来实现它。
 


### PR DESCRIPTION
- 对于插件名称翻译的部分, 与vscode保持一致。

[对于插件名称翻译的讨论](https://github.com/windicss/docs-cn/pull/6#discussion_r639411199)